### PR TITLE
feat: Replace custom coordinate math with geolib

### DIFF
--- a/hooks/useEnhancedDriverNavigation.ts
+++ b/hooks/useEnhancedDriverNavigation.ts
@@ -1,4 +1,5 @@
 // hooks/useEnhancedDriverNavigation.ts - Fixed version
+import { getBearing, getDistance } from 'geolib';
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Alert } from 'react-native';
 import { useLocation } from '@/hooks/Location/useLocation';
@@ -117,17 +118,7 @@ export const useEnhancedDriverNavigation = ({
         }
 
         try {
-            const lat1 = lastLocation.coords.latitude * Math.PI / 180;
-            const lng1 = lastLocation.coords.longitude * Math.PI / 180;
-            const lat2 = newLocation.coords.latitude * Math.PI / 180;
-            const lng2 = newLocation.coords.longitude * Math.PI / 180;
-
-            const dLng = lng2 - lng1;
-            const y = Math.sin(dLng) * Math.cos(lat2);
-            const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
-
-            let bearing = Math.atan2(y, x) * 180 / Math.PI;
-            bearing = (bearing + 360) % 360; // Normalize to 0-360
+            const bearing = getBearing(lastLocation.coords, newLocation.coords);
 
             // Validate calculated bearing
             if (!isValidNumber(bearing)) {
@@ -163,19 +154,7 @@ export const useEnhancedDriverNavigation = ({
         }
 
         try {
-            const R = 6371e3; // Earth's radius in meters
-            const φ1 = lat1 * Math.PI / 180;
-            const φ2 = lat2 * Math.PI / 180;
-            const Δφ = (lat2 - lat1) * Math.PI / 180;
-            const Δλ = (lng2 - lng1) * Math.PI / 180;
-
-            const a = Math.sin(Δφ/2) * Math.sin(Δφ/2) +
-                Math.cos(φ1) * Math.cos(φ2) *
-                Math.sin(Δλ/2) * Math.sin(Δλ/2);
-            const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-
-            const distance = R * c;
-            return isValidNumber(distance) ? Math.max(0, distance) : 0;
+            return getDistance({ latitude: lat1, longitude: lng1 }, { latitude: lat2, longitude: lng2 });
         } catch (error) {
             console.warn('Error calculating distance:', error);
             return 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "expo-system-ui": "~5.0.9",
         "expo-web-browser": "~14.2.0",
         "geojson": "^0.5.0",
+        "geolib": "^3.3.4",
         "nativewind": "^4.1.23",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -8651,6 +8652,12 @@
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
       "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
+      "license": "MIT"
+    },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==",
       "license": "MIT"
     },
     "node_modules/get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-system-ui": "~5.0.9",
     "expo-web-browser": "~14.2.0",
     "geojson": "^0.5.0",
+    "geolib": "^3.3.4",
     "nativewind": "^4.1.23",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/services/CustomNavigationService.ts
+++ b/services/CustomNavigationService.ts
@@ -1,4 +1,5 @@
 // services/CustomNavigationService.ts
+import { getDistance } from 'geolib';
 import { DirectionsService } from '@/components/DirectionsService';
 import * as Location from 'expo-location';
 
@@ -241,15 +242,7 @@ export class CustomNavigationService {
         point1: { latitude: number; longitude: number },
         point2: { latitude: number; longitude: number }
     ): number {
-        const R = 6371000; // Earth's radius in meters
-        const dLat = (point2.latitude - point1.latitude) * Math.PI / 180;
-        const dLon = (point2.longitude - point1.longitude) * Math.PI / 180;
-        const a =
-            Math.sin(dLat/2) * Math.sin(dLat/2) +
-            Math.cos(point1.latitude * Math.PI / 180) * Math.cos(point2.latitude * Math.PI / 180) *
-            Math.sin(dLon/2) * Math.sin(dLon/2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-        return R * c;
+        return getDistance(point1, point2);
     }
 
     private announceInstruction(instruction: NavigationInstruction) {

--- a/services/OSRMNavigationService.ts
+++ b/services/OSRMNavigationService.ts
@@ -1,4 +1,5 @@
 // services/OSRMNavigationService.ts - Enhanced with Better Route Handling
+import { findNearest, getDistance, isPointNearLine } from 'geolib';
 import * as Location from 'expo-location';
 
 export interface NavigationCoordinates {
@@ -492,36 +493,12 @@ export class OSRMNavigationService {
         lineStart: NavigationCoordinates,
         lineEnd: NavigationCoordinates
     ): number {
-        const A = point.longitude - lineStart.longitude;
-        const B = point.latitude - lineStart.latitude;
-        const C = lineEnd.longitude - lineStart.longitude;
-        const D = lineEnd.latitude - lineStart.latitude;
-
-        const dot = A * C + B * D;
-        const lenSq = C * C + D * D;
-        let param = -1;
-
-        if (lenSq !== 0) {
-            param = dot / lenSq;
+        if (isPointNearLine(point, lineStart, lineEnd, 1)) {
+            return 0;
         }
 
-        let xx, yy;
-
-        if (param < 0) {
-            xx = lineStart.longitude;
-            yy = lineStart.latitude;
-        } else if (param > 1) {
-            xx = lineEnd.longitude;
-            yy = lineEnd.latitude;
-        } else {
-            xx = lineStart.longitude + param * C;
-            yy = lineStart.latitude + param * D;
-        }
-
-        const dx = point.longitude - xx;
-        const dy = point.latitude - yy;
-
-        return Math.sqrt(dx * dx + dy * dy) * 111320; // Convert to meters
+        const perpendicularPoint = findNearest(point, [lineStart, lineEnd]);
+        return getDistance(point, perpendicularPoint);
     }
 
     private hasArrivedAtDestination(location: Location.LocationObject): boolean {
@@ -541,15 +518,7 @@ export class OSRMNavigationService {
         point1: Location.LocationObjectCoords | NavigationCoordinates,
         point2: NavigationCoordinates
     ): number {
-        const R = 6371000; // Earth's radius in meters
-        const dLat = (point2.latitude - point1.latitude) * Math.PI / 180;
-        const dLon = (point2.longitude - point1.longitude) * Math.PI / 180;
-        const a =
-            Math.sin(dLat/2) * Math.sin(dLat/2) +
-            Math.cos(point1.latitude * Math.PI / 180) * Math.cos(point2.latitude * Math.PI / 180) *
-            Math.sin(dLon/2) * Math.sin(dLon/2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-        return R * c;
+        return getDistance(point1, point2);
     }
 
     stopNavigation(): void {


### PR DESCRIPTION
I replaced custom implementations of Haversine formula and other coordinate math with functions from the `geolib` library in the following files:

- `services/CustomNavigationService.ts`
- `services/OSRMNavigationService.ts`
- `hooks/useEnhancedDriverNavigation.ts`

This improves accuracy and maintainability.